### PR TITLE
fix: don't store incoming connections in peers map

### DIFF
--- a/src/openraft/node.rs
+++ b/src/openraft/node.rs
@@ -535,6 +535,23 @@ impl OpenRaftNode {
                                 data: bytes::Bytes::from(response_data),
                             }
                         }
+                        crate::rpc::RequestPayload::Custom { operation, data } if operation == "propose" => {
+                            // Handle forwarded propose requests from followers
+                            tracing::info!(
+                                "Node {}: Received forwarded propose request",
+                                node_id
+                            );
+                            match raft.client_write(AppEntry(data.to_vec())).await {
+                                Ok(resp) => crate::rpc::ResponsePayload::CustomResponse {
+                                    success: true,
+                                    data: bytes::Bytes::from(resp.data.0),
+                                },
+                                Err(e) => crate::rpc::ResponsePayload::CustomResponse {
+                                    success: false,
+                                    data: bytes::Bytes::from(e.to_string()),
+                                },
+                            }
+                        }
                         _ => crate::rpc::ResponsePayload::CustomResponse {
                             success: false,
                             data: bytes::Bytes::new(),
@@ -610,12 +627,49 @@ impl OpenRaftNode {
                 "propose leader id mismatch",
             );
         }
-        let resp = self
-            .raft
-            .client_write(AppEntry(command))
-            .await
-            .map_err(|e| crate::error::OctopiiError::Rpc(format!("client_write: {e}")))?;
-        Ok(Bytes::from(resp.data.0))
+
+        // Check if we're the leader
+        let metrics = self.raft.metrics().borrow().clone();
+        if metrics.state == ServerState::Leader {
+            // We're the leader, propose directly
+            let resp = self
+                .raft
+                .client_write(AppEntry(command))
+                .await
+                .map_err(|e| crate::error::OctopiiError::Rpc(format!("client_write: {e}")))?;
+            return Ok(Bytes::from(resp.data.0));
+        }
+
+        // Not leader - forward to leader
+        let leader_id = metrics.current_leader
+            .ok_or_else(|| crate::error::OctopiiError::Rpc("No leader elected".to_string()))?;
+
+        let leader_addr = self.peer_addr_for(leader_id).await
+            .ok_or_else(|| crate::error::OctopiiError::NodeNotFound(leader_id))?;
+
+        tracing::info!(
+            "Node {}: Forwarding propose to leader {} at {}",
+            self.config.node_id, leader_id, leader_addr
+        );
+
+        // Forward via RPC
+        let response = self.rpc.request(
+            leader_addr,
+            crate::rpc::RequestPayload::Custom {
+                operation: "propose".to_string(),
+                data: Bytes::from(command),
+            },
+            Duration::from_secs(5),
+        ).await?;
+
+        match response.payload {
+            crate::rpc::ResponsePayload::CustomResponse { success: true, data } => Ok(data),
+            crate::rpc::ResponsePayload::CustomResponse { success: false, data } => {
+                Err(crate::error::OctopiiError::Rpc(String::from_utf8_lossy(&data).to_string()))
+            }
+            crate::rpc::ResponsePayload::Error { message } => Err(crate::error::OctopiiError::Rpc(message)),
+            _ => Err(crate::error::OctopiiError::Rpc("Unexpected response from leader".to_string())),
+        }
     }
 
     pub async fn query(&self, command: &[u8]) -> Result<Bytes> {

--- a/src/openraft/node.rs
+++ b/src/openraft/node.rs
@@ -291,10 +291,11 @@ impl OpenRaftNode {
 
         // Create Raft config
         // Use longer timeouts to be more forgiving in real-world networks
+        // Note: heartbeat_interval is used as the timeout for AppendEntries RPCs
         let mut raft_config = RaftConfig::default();
-        raft_config.heartbeat_interval = 1000;    // 1 second (was 200ms)
-        raft_config.election_timeout_min = 3000;  // 3 seconds (was 800ms)
-        raft_config.election_timeout_max = 5000;  // 5 seconds (was 1600ms)
+        raft_config.heartbeat_interval = 3000;    // 3 seconds (was 200ms) - also used as AppendEntries RPC timeout
+        raft_config.election_timeout_min = 6000;  // 6 seconds (was 800ms)
+        raft_config.election_timeout_max = 10000; // 10 seconds (was 1600ms)
         #[cfg(feature = "simulation")]
         {
             raft_config.allow_log_reversion = Some(true);

--- a/src/openraft/node.rs
+++ b/src/openraft/node.rs
@@ -290,10 +290,11 @@ impl OpenRaftNode {
         );
 
         // Create Raft config
+        // Use longer timeouts to be more forgiving in real-world networks
         let mut raft_config = RaftConfig::default();
-        raft_config.heartbeat_interval = 200;
-        raft_config.election_timeout_min = 800;
-        raft_config.election_timeout_max = 1600;
+        raft_config.heartbeat_interval = 1000;    // 1 second (was 200ms)
+        raft_config.election_timeout_min = 3000;  // 3 seconds (was 800ms)
+        raft_config.election_timeout_max = 5000;  // 5 seconds (was 1600ms)
         #[cfg(feature = "simulation")]
         {
             raft_config.allow_log_reversion = Some(true);

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -195,10 +195,18 @@ impl RpcHandler {
         req: RpcRequest,
         peer: Option<Arc<dyn Peer>>,
     ) {
+        let req_id = req.id;
+        tracing::info!("handle_request: processing request {} from {}", req_id, addr);
+
         let handler = self.request_handler.read().await;
 
         let response_payload = match handler.as_ref() {
-            Some(h) => h(req.clone()).await,
+            Some(h) => {
+                tracing::debug!("handle_request: invoking handler for request {}", req_id);
+                let result = h(req.clone()).await;
+                tracing::debug!("handle_request: handler completed for request {}", req_id);
+                result
+            }
             None => ResponsePayload::Error {
                 message: "No request handler registered".to_string(),
             },
@@ -209,9 +217,11 @@ impl RpcHandler {
         // Send response back on the same connection if peer is provided,
         // otherwise fall back to creating a new connection
         if let Ok(data) = serialize(&response) {
+            tracing::info!("handle_request: sending response for request {} ({} bytes) to {}", req_id, data.len(), addr);
             if let Some(peer) = peer {
-                if let Err(e) = peer.send(data).await {
-                    tracing::error!("Failed to send response via peer: {}", e);
+                match peer.send(data).await {
+                    Ok(()) => tracing::info!("handle_request: response sent successfully for request {}", req_id),
+                    Err(e) => tracing::error!("Failed to send response via peer for request {}: {}", req_id, e),
                 }
             } else {
                 if let Err(e) = self.transport.send(addr, data).await {
@@ -232,25 +242,39 @@ impl RpcHandler {
     async fn ensure_peer_receiver(self: &Arc<Self>, addr: SocketAddr, peer: Arc<dyn Peer>) {
         let mut receivers = self.peer_receivers.lock().await;
         if receivers.contains(&addr) {
+            tracing::debug!("Receiver already exists for {}", addr);
             return;
         }
         receivers.insert(addr);
         drop(receivers);
 
+        tracing::info!("Starting receive loop for peer {}", addr);
         let rpc = Arc::clone(self);
         tokio::spawn(async move {
+            tracing::info!("Receive loop started for peer {}", addr);
             loop {
+                tracing::debug!("Receive loop: waiting for message from {}", addr);
                 match peer.recv().await {
-                    Ok(Some(data)) => match deserialize::<RpcMessage>(&data) {
-                        Ok(msg) => {
-                            rpc.notify_message(addr, msg, Some(Arc::clone(&peer))).await;
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to deserialize RPC message from {}: {}",
-                                addr,
-                                e
-                            );
+                    Ok(Some(data)) => {
+                        tracing::info!("Receive loop: got {} bytes from {}", data.len(), addr);
+                        match deserialize::<RpcMessage>(&data) {
+                            Ok(msg) => {
+                                let msg_type = match &msg {
+                                    RpcMessage::Request(r) => format!("Request(id={})", r.id),
+                                    RpcMessage::Response(r) => format!("Response(id={})", r.id),
+                                    RpcMessage::OneWay(_) => "OneWay".to_string(),
+                                };
+                                tracing::info!("Receive loop: processing {} from {}", msg_type, addr);
+                                rpc.notify_message(addr, msg, Some(Arc::clone(&peer))).await;
+                                tracing::debug!("Receive loop: done processing message from {}", addr);
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to deserialize RPC message from {}: {}",
+                                    addr,
+                                    e
+                                );
+                            }
                         }
                     },
                     Ok(None) => {
@@ -264,6 +288,7 @@ impl RpcHandler {
                 }
             }
 
+            tracing::info!("Receive loop ended for peer {}", addr);
             let mut receivers = rpc.peer_receivers.lock().await;
             receivers.remove(&addr);
         });

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -121,6 +121,12 @@ impl QuicTransport {
     }
 
     /// Accept incoming connections
+    ///
+    /// Note: Incoming connections are NOT stored in the peers map to avoid
+    /// conflating them with outgoing connections. In QUIC, when a client bound
+    /// to port X connects to a server, the server sees remote_addr as X.
+    /// If we also have an outgoing connection to X, storing the incoming
+    /// connection would overwrite it and break bidirectional communication.
     pub async fn accept(&self) -> Result<(SocketAddr, Arc<PeerConnection>)> {
         let incoming = self
             .endpoint
@@ -133,9 +139,8 @@ impl QuicTransport {
 
         let peer = Arc::new(PeerConnection::new(connection));
 
-        // Store in peers map
-        let mut peers = self.peers.write().await;
-        peers.insert(remote_addr, Arc::clone(&peer));
+        // Don't store incoming connections in peers map - they could conflict
+        // with outgoing connections to the same address
 
         tracing::info!("Accepted connection from {}", remote_addr);
 


### PR DESCRIPTION
## Problem

In `QuicTransport::accept()`, incoming connections are stored in the `peers` map using the remote address as key. This can overwrite existing outgoing connections to the same address, breaking bidirectional RPC communication.

## Solution

Don't store incoming connections in the `peers` map. Only outgoing connections initiated via `connect()` should be tracked there.

```rust
// Before (buggy)
pub async fn accept(&self) -> Result<(SocketAddr, Arc<PeerConnection>)> {
    let incoming = self.endpoint.accept().await...;
    let peer = Arc::new(PeerConnection::new(connection));
    peers.insert(remote_addr, Arc::clone(&peer));  // overwrites outgoing connection
    Ok((remote_addr, peer))
}

// After (fixed)
pub async fn accept(&self) -> Result<(SocketAddr, Arc<PeerConnection>)> {
    let incoming = self.endpoint.accept().await...;
    let peer = Arc::new(PeerConnection::new(connection));
    // Don't store - incoming connections could conflict with outgoing ones
    Ok((remote_addr, peer))
}
```

## Additional Changes

- Automatic write forwarding from followers to leader in `propose()`
- Increased default Raft timeouts for better reliability